### PR TITLE
[cmake] Use FetchContent and the correct ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+# FetchContent from CMake >= 3.11
+cmake_minimum_required(VERSION 3.11)
 
 set(CXX_DISABLE_WERROR 1)
 set(CMAKE_CXX_STANDARD 14)
@@ -9,6 +10,16 @@ set(PROJECT_URL "https://github.com/rohanpsingh/mc_reacher_policy")
 
 project(${PROJECT_NAME} CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
+
+if(NOT EXISTS ${PROJECT_SOURCE_DIR}/ext/libtorch)
+  include(FetchContent)
+  FetchContent_Declare(libtorch
+    URL https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-with-deps-latest.zip
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/ext/libtorch
+  )
+  FetchContent_Populate(libtorch)
+endif()
+
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/ext/libtorch)
 
 # Check if the project is built inside mc_rtc

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ mc-rtc controller for 3D reacher task using learned (RL) policy.
 ```sh
 $ git clone https://github.com/rohanpsingh/mc_reacher_policy.git
 ```
-- Download `libtorch` and put it in a directory called `ext/`:
-```sh
-$ cd mc_reacher_policy
-$ mkdir ext && cd ext
-$ wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip
-$ unzip libtorch-shared-with-deps-latest.zip
-```
 - Build and install
 ```
 $ cd mc_reacher_policy
@@ -21,7 +14,6 @@ $ mkdir build && cd build
 $ cmake ..
 $ make -j8 install
 ```
-
 
 ## USAGE
 


### PR DESCRIPTION
This PR:
- Uses `FetchContent` to simplify the setup
- Fetch the cxx11-abi packages to match the ABI used by mc_rtc